### PR TITLE
Update module.json to allow install for any dnd5e v5

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -34,7 +34,7 @@
         "compatibility": {
           "minimum": "4.2.0",
           "verified": "5.0.1",
-          "maximum": "5.0.x"
+          "maximum": "5.x"
         }
       }
     ],


### PR DESCRIPTION
I was getting blocked from installing on dnd v5.1, so this change allows the module to be installed on any v5.